### PR TITLE
Cancel cropper fix

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -902,7 +902,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
 
 - (void)cropViewController:(TOCropViewController *)cropViewController didFinishCancelled:(BOOL)cancelled {
     [self dismissCropper:cropViewController selectionDone:NO completion:[self waitAnimationEnd:^{
-        if (self.currentSelectionMode == CROPPING) {
+        if (self.currentSelectionMode == CROPPING || self.currentSelectionMode == CAMERA) {
             self.reject(ERROR_PICKER_CANCEL_KEY, ERROR_PICKER_CANCEL_MSG, nil);
         }
     }]];


### PR DESCRIPTION
Thread here: https://github.com/ivpusic/react-native-image-crop-picker/issues/844

Cancelling out of the cropper was not working as expected, as it would not resolve or throw an error to handle in a catch block. By replacing one line in the ImageCropPicker.m file (recommended in the above thread) the cropper can be cancelled as expected.